### PR TITLE
Package as flake with deps to run on nix systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ If you prefer to get the newest version and compile it yourself, follow these st
     cp resources/english.txt ~/.local/share/typy/
     ```
 
+If you have Nix with flakes enabled, you can install typy-cli directly:
+
+```bash
+nix profile install github:Pazl27/typy-cli
+```
+
+Or to run without installing:
+
+```bash
+nix run github:Pazl27/typy-cli
+```
+
 ## Flags
 The `Typy` application supports the following flags:
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1740560979,
+        "narHash": "sha256-Vr3Qi346M+8CjedtbyUevIGDZW8LcA1fTG0ugPY/Hic=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5135c59491985879812717f4c9fea69604e7f26f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1740623427,
+        "narHash": "sha256-3SdPQrZoa4odlScFDUHd4CUPQ/R1gtH4Mq9u8CBiK8M=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "d342e8b5fd88421ff982f383c853f0fc78a847ab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,55 @@
+{
+  description = "typy-cli - Minimalistic Monkeytype clone for the CLI";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = { self, nixpkgs, rust-overlay, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+        
+        buildInputs = with pkgs; [ ];
+
+        nativeBuildInputs = with pkgs; [
+          rust-bin.stable.latest.default
+          pkg-config
+          makeWrapper
+        ];
+
+      in
+      {
+        packages.default = pkgs.rustPlatform.buildRustPackage {
+          pname = "typy-cli";
+          version = "0.7.0";
+          src = ./.;
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+          };
+          inherit buildInputs nativeBuildInputs;
+          postInstall = ''
+            mkdir -p $out/share/typy
+            cp $src/resources/english.txt $out/share/typy/english.txt
+
+            wrapProgram $out/bin/typy-cli \
+            --run "mkdir -p ~/.local/share/typy" \
+            --run "cp -n $out/share/typy/english.txt ~/.local/share/typy/english.txt"
+            '';
+
+          meta = with pkgs.lib; {
+            description = "typy-cli - Minimalistic Monkeytype clone for the CLI";
+            homepage = "https://github.com/Pazl27/typy-cli";
+            license = licenses.mit;
+          };
+        };
+      }
+  );
+}
+


### PR DESCRIPTION
Awesome work on this CLI! I love monkeytype and Rust, and this is a great tool.

I'm opening this PR to make it easier for Nix users (like myself) to install and use your CLI. This PR adds the necessary flake config to run the CLI w/o installing with `nix run github:Pazl27:typy-cli` or let users depend on this package in other nix flakes.

### Changes

1. Adds a [Nix flake] to allow NixOS/[home-manager] users to easily run and install the CLI manually copying `english.txt`, etc
    1. Builds CLI cargo package
    2. Installs `english.txt` during build process so user can immediately start using, similar to current install script
3. Update README with instructions to install/run the flake 

[Nix flake]: https://zero-to-nix.com/concepts/flakes/
[home-manager]: https://nix-community.github.io/home-manager/


### Testing

[![asciicast](https://asciinema.org/a/PAgVTYUuVrNVm2QIPB2bYTcu4.svg)](https://asciinema.org/a/PAgVTYUuVrNVm2QIPB2bYTcu4)