### PR TITLE
chore: update nix flake binary package name, lockfile

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740560979,
-        "narHash": "sha256-Vr3Qi346M+8CjedtbyUevIGDZW8LcA1fTG0ugPY/Hic=",
+        "lastModified": 1743583204,
+        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5135c59491985879812717f4c9fea69604e7f26f",
+        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740623427,
-        "narHash": "sha256-3SdPQrZoa4odlScFDUHd4CUPQ/R1gtH4Mq9u8CBiK8M=",
+        "lastModified": 1743820323,
+        "narHash": "sha256-UXxJogXhPhBFaX4uxmMudcD/x3sEGFtoSc4busTcftY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d342e8b5fd88421ff982f383c853f0fc78a847ab",
+        "rev": "b4734ce867252f92cdc7d25f8cc3b7cef153e703",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
             mkdir -p $out/share/typy
             cp $src/resources/english.txt $out/share/typy/english.txt
 
-            wrapProgram $out/bin/typy-cli \
+            wrapProgram $out/bin/typy \
             --run "mkdir -p ~/.local/share/typy" \
             --run "cp -n $out/share/typy/english.txt ~/.local/share/typy/english.txt"
             '';


### PR DESCRIPTION
Update package name since binary package name changed (https://github.com/Pazl27/typy-cli/blob/4c9fad4c41e93dd7f8d211d32936991557e14540/Cargo.toml#L2)

### Testing

Before, was using more verbose name "typy-cli", now use preferred shorter "typy".


```
typy-cli on  master [!] is 📦 v0.7.0 via 🦀 v1.86.0-nightly on ☁️  (us-west-2) took 1m36s
❯ nix build
warning: Git tree '/Users/camdurha/tools/contrib/typy-cli' is dirty
warning: download buffer is full; consider increasing the 'download-buffer-size' setting

typy-cli on  master [!?] is 📦 v0.7.0 via 🦀 v1.86.0-nightly on ☁️  (us-west-2) took 2s
❯ ls result/bin/typy
result/bin/typy*
```