### PR TITLE
fix: reset terminal on early quit (Esc/Ctrl+C) in tmux

### DIFF
--- a/src/terminal/game.rs
+++ b/src/terminal/game.rs
@@ -168,10 +168,9 @@ pub fn run(mode: Mode, theme: ThemeColors) -> Result<()> {
         );
         Data::save_data(score).context("Failed to save data")?;
         finish_overview::show_stats(&stdout, stats, &theme).context("Failed to show stats")?;
+    } else {
+        reset_terminal(&stdout).context("Failed to reset terminal")?;
     }
-
-    reset_terminal(&stdout).context("Failed to reset terminal")?;
-    timer_expired.store(true, Ordering::Relaxed);
     timer_thread
         .join()
         .map_err(|e| anyhow::anyhow!("Failed to join timer thread: {:?}", e))?;


### PR DESCRIPTION
## Bug: Terminal left in raw mode on early quit

Issue: #1 Bug: Terminal output

When quitting via Esc or Ctrl+C (before timer expires), reset_terminal() was not being called, leaving the terminal in raw mode with hidden cursor. This manifests in tmux where terminal state is managed more strictly.

Root cause: In the run() function, reset_terminal() was only called after the normal completion path. The early-quit path (setting game.quit = true) broke out of the loop without resetting terminal state.

Fix: Move reset_terminal() into an else block so it runs on early quit as well.